### PR TITLE
Adusted build.gradle and fixes a bug with Nbt#toByteArray returning an empty array

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ uploadArchives {
             }
 
             repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: hasProperty('ossrhUsername')?ossrhUsername:'', password: hasProperty('ossrhPassword')?ossrhPassword:'')
             }
 
             pom.project {

--- a/src/main/java/dev/dewy/nbt/Nbt.java
+++ b/src/main/java/dev/dewy/nbt/Nbt.java
@@ -154,7 +154,7 @@ public class Nbt {
      */
     public byte[] toByteArray(@NonNull CompoundTag compound) throws IOException {
         @Cleanup ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        @Cleanup DataOutputStream w = new DataOutputStream(new BufferedOutputStream(baos));
+        @Cleanup DataOutputStream w = new DataOutputStream(baos);
 
         this.toStream(compound, w);
 


### PR DESCRIPTION
Changed build.gradle so building works, when ossrhUsername or ossrhPassword is not set and fixed a bug where Nbt#toByteArray would give an empty array, because it was buffered by the BufferedOutputStream