### PR TITLE
Fix Nbt.toByteArray() returning an empty array

### DIFF
--- a/src/main/java/dev/dewy/nbt/Nbt.java
+++ b/src/main/java/dev/dewy/nbt/Nbt.java
@@ -154,7 +154,7 @@ public class Nbt {
      */
     public byte[] toByteArray(@NonNull CompoundTag compound) throws IOException {
         @Cleanup ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        @Cleanup DataOutputStream w = new DataOutputStream(new BufferedOutputStream(baos));
+        @Cleanup DataOutputStream w = new DataOutputStream(baos);
 
         this.toStream(compound, w);
 


### PR DESCRIPTION
The BufferedOutputStream needs to be flushed or removed. I've gone with removed since it is not writing to the disk.